### PR TITLE
Fixed aggreate aliasing not working properly

### DIFF
--- a/src/queries/select.coffee
+++ b/src/queries/select.coffee
@@ -56,10 +56,11 @@ module.exports = class SelectQuery extends SUDQuery
     Example::
 
       select('t1', function (q) { q.agg('count', q.p('id')) }) # SELECT count(id) FROM t1
-    
+      select('t1', function (q) { q.agg({counter: 'count'}, q.p('id')) }) # SELECT count(id) AS "counter" FROM t1
+
     ###
     if alias = getAlias fun
-      @q.projections.addNode sqlFunction(fun, fields).as(alias)
+      @q.projections.addNode sqlFunction(fun[alias], fields).as(alias)
     else
       @q.projections.addNode sqlFunction(fun, fields)
 


### PR DESCRIPTION
Hey again, previously

``` coffee
select('t1', function (q) { q.agg({'foobar': 'count'}, q.p('id')) })
```

Would compile to

``` sql
SELECT ([object Object](t1.id)) AS foobar FROM t1
```

This fix makes it compile to

``` sql
SELECT count(t1.id) AS foobar FROM t1
```
