### PR TITLE
Use 'latest' any-db instead of '*'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": ">=0.4.0"
   },
   "dependencies": {
-    "any-db": "*"
+    "any-db": "latest"
   },
   "devDependencies": {
     "coffee-script": "~1.4.0",


### PR DESCRIPTION
If gesundheit is updated to use features (or fixes) in new `any-db`
version, existing `gesundheit` users will not get the updated
any-db version since any version can satisfy '*' thus the module
will occasionally break in strange ways when you make updates
to either module.

Further, `npm update gesundheit` won't fix it because '*' is
already satisfied with the buggy version (same issue) leading
to confusion.

I assumed that 'latest' is what is meant by specifying '*'.
That is, gesundheit is tightly coupled to any-db so there is no
point in specifying exact versions and both should be updated
together.
