### PR TITLE
fix unmarshaling of Join objects

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -365,7 +365,7 @@ class Join extends FixedNodeSet
     {nodes} = data
     join = new @(recur(nodes[0]), recur(nodes[2]))
     for clause in nodes.slice(4)
-      join.on(clause)
+      join.on(recur(clause))
     join
 
   constructor: (@type, @relation) ->


### PR DESCRIPTION
There's currently a bug that incorrectly unmarshals joins, which means you can't `.copy()` a query that has joins. As far as I can tell this pull request fixes it, but please review to make sure there are no unintended consequences.
